### PR TITLE
Fix remaining TypeScript errors in composeEmail.ts

### DIFF
--- a/album-anniversaries/tsconfig.json
+++ b/album-anniversaries/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es2021", "dom"],
     "typeRoots": ["./types", "./node_modules/@types"],
     "types": ["node", "convert-csv-to-json"]
   }

--- a/album-anniversaries/utils/composeEmail.ts
+++ b/album-anniversaries/utils/composeEmail.ts
@@ -10,7 +10,7 @@ export const composeEmail = (
     artist: string;
   }[]
 ) => {
-  const variableContent = (anniversaryObjects) => {
+  const variableContent = (anniversaryObjects: Parameters<typeof composeEmail>[1]) => {
     if (anniversaryObjects.length === 0) {
       return "And there are no albums _Audioxide_ has reviewed celebrating an anniversary of note this week. Too bad. Maybe try pulling your finger out and reviewing more albums, you slobs.\n";
     }


### PR DESCRIPTION
Fixes two more TypeScript errors now surfacing in `utils/composeEmail.ts`.

- **TS7006** (`anniversaryObjects` / `album` implicit any): typed the inner `variableContent` function parameter using `Parameters<typeof composeEmail>[1]` so it mirrors the outer function's signature without duplicating the type
- **TS2550** (`replaceAll` not found): bumped `lib` from `es2017` to `es2021` — `replaceAll` was added in ES2021